### PR TITLE
feat: Publisher로부터 주기적으로 센싱값을 받아 외부 API로 송신 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,8 @@
 .idea/**/dbnavigator.xml
 
 jinwon-tcplocalhost1883
+config/
+*.yml
 
 # Gradle
 .idea/**/gradle.xml

--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,9 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.2.5'
+	implementation group: 'org.springframework.boot', name: 'spring-boot-starter-webflux'
+	implementation("io.netty:netty-resolver-dns-native-macos:4.1.79.Final:osx-aarch_64")
+//	implementation 'io.netty:netty-tcnative-boringssl-static:2.0.35.Final'
 	runtimeOnly 'com.h2database:h2'
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'

--- a/src/main/java/io/wisoft/mqtt/application/MqttSubscriberService.java
+++ b/src/main/java/io/wisoft/mqtt/application/MqttSubscriberService.java
@@ -1,15 +1,19 @@
 package io.wisoft.mqtt.application;
 
 import org.eclipse.paho.client.mqttv3.*;
-import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
 
-@Component
+@Service
 public class MqttSubscriberService implements MqttCallback {
 
     private MqttClient mqttClient;
     private MqttConnectOptions mqttOptions;
 
-    public MqttSubscriberService init(String server, String clientId) throws MqttException {
+    @Autowired
+    private WebClientService webClientService;
+
+    public MqttSubscriberService init(final String server, final String clientId) throws MqttException {
 
         mqttOptions = new MqttConnectOptions();
         mqttOptions.setCleanSession(true);
@@ -23,20 +27,22 @@ public class MqttSubscriberService implements MqttCallback {
 
     // 커넥션이 종료되면 호출 - 통신 오류로 연결이 끊어지는 경우 호출
     @Override
-    public void connectionLost(Throwable cause) {
+    public void connectionLost(final Throwable cause) {
         System.out.println("연결이 중단되었습니다.");
+        System.out.println(cause);
     }
 
     // 메시지가 도착하면 호출
     @Override
-    public void messageArrived(String topic, MqttMessage message) throws Exception {
+    public void messageArrived(final String topic, final MqttMessage message) throws Exception {
         System.out.println("메시지도착");
         System.out.println(message);
         System.out.println("topic = " + topic + ", id = " + message.getId() + ", payload = " + new String(message.getPayload()));
+        webClientService.post(message);
     }
 
     // 구독 신청
-    public boolean subscribe(String topic) throws MqttException {
+    public boolean subscribe(final String topic) throws MqttException {
 
         if (topic != null) {
             mqttClient.subscribe(topic, 0);
@@ -47,7 +53,6 @@ public class MqttSubscriberService implements MqttCallback {
 
     // 메시지의 배달이 완료되면 호출
     @Override
-    public void deliveryComplete(IMqttDeliveryToken token) {
-
+    public void deliveryComplete(final IMqttDeliveryToken token) {
     }
 }

--- a/src/main/java/io/wisoft/mqtt/application/WebClientService.java
+++ b/src/main/java/io/wisoft/mqtt/application/WebClientService.java
@@ -1,0 +1,66 @@
+package io.wisoft.mqtt.application;
+
+import io.wisoft.mqtt.config.MqttConfig;
+import org.eclipse.paho.client.mqttv3.MqttMessage;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.StringTokenizer;
+
+import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
+import static org.springframework.http.MediaType.*;
+
+@Service
+public class WebClientService {
+
+    MqttConfig mqttConfig = new MqttConfig();
+
+    public void requestToApiServer(final MqttMessage message) {
+
+        Map<String, Object> bodyMap = extractdata(message);
+
+        final WebClient webClient = WebClient
+                .builder()
+                .baseUrl(mqttConfig.baseUrl)
+                .defaultHeader(CONTENT_TYPE, APPLICATION_JSON_VALUE)
+                .build();
+
+        final Map<String, Object> response = (Map<String, Object>) webClient
+                .post()
+                .uri(mqttConfig.apiUrl)
+                .bodyValue(bodyMap)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+    }
+
+    public static void post(final MqttMessage message) {
+        final WebClientService webClientService = new WebClientService();
+        webClientService.requestToApiServer(message);
+    }
+
+    private Map<String, Object> extractdata(final MqttMessage message) {
+
+        final Map<String, Object> bodyMap = new HashMap<>();
+
+        final String str = new String(message.getPayload());
+        final StringTokenizer st = new StringTokenizer(str, "=,");
+
+        st.nextToken();
+        final Long id = Long.valueOf(st.nextToken());
+
+        st.nextToken();
+        final Double number = Double.valueOf(st.nextToken());
+
+        st.nextToken();
+        final String measurement = st.nextToken();
+
+        bodyMap.put("memberId", id);
+        bodyMap.put("value", number);
+        bodyMap.put("measurement", measurement);
+
+        return bodyMap;
+    }
+}


### PR DESCRIPTION
### feat:
- Publisher로부터 주기적으로 센싱값을 받습니다.
- 수신받은 데이터를 API 서버팀의 외부 API로 송신하는 기능을 추가하였습니다.

</br>

### ETC
- 서버 url 및 API url은 config 파일로 관리합니다.